### PR TITLE
Update RelationshipsLinkList.php

### DIFF
--- a/src/RelationshipsLinkList.php
+++ b/src/RelationshipsLinkList.php
@@ -44,10 +44,13 @@ class RelationshipsLinkList extends Field
             return '—';
         }
 
+        $path = nova::path();
+        $path .= (substr($path, -1) == '/' ? '' : '/');
+
         return $resource
             ->{$attribute}
-            ->map(function ($model) use ($resource, $attribute) {
-                return '<a class="no-underline dim text-primary font-bold" href="'.url(Nova::path().'/resources/'.$attribute.'/'.$model->id).'">'.$model->name.'</a>';
+            ->map(function ($model) use ($resource, $attribute, $path) {
+                return '<a class="no-underline dim text-primary font-bold" href="'.url($path.'resources/'.$attribute.'/'.$model->id).'">'.$model->name.'</a>';
             })
             ->implode(', ');
     }


### PR DESCRIPTION
Hi @andrewminion-luminfire 

As described in #1 , this resolves broken links when the path is set to `/`

There might be a more elegant way to do this so will leave it to you, I've added a check to add the trailing forward slash in case the user has path set without one. 

All the best